### PR TITLE
Revising target build framework to 4.6

### DIFF
--- a/SearchIndexBuilder.App/App.config
+++ b/SearchIndexBuilder.App/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/SearchIndexBuilder.App/SearchIndexBuilder.App.csproj
+++ b/SearchIndexBuilder.App/SearchIndexBuilder.App.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SearchIndexBuilder.App</RootNamespace>
     <AssemblyName>SearchIndexBuilder.App</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Retargeting the build to Fwk 4.6 to increase compatibility with older Sitecore releases.
Initial attempt to improve situation raised in issue #4 