### PR TITLE
Catching disk permission exceptions when managing endpoint

### DIFF
--- a/SearchIndexBuilder.App/Processors/Deploy/DeployProcessor.cs
+++ b/SearchIndexBuilder.App/Processors/Deploy/DeployProcessor.cs
@@ -45,14 +45,32 @@ namespace SearchIndexBuilder.App.Processors.Deploy
                 return;
             }
 
-            writeResourceToFile($"SearchIndexBuilder.App.Endpoint.{file}", fileName);
+            try
+            {
+                writeResourceToFile($"SearchIndexBuilder.App.Endpoint.{file}", fileName);
+            }
+            catch(UnauthorizedAccessException)
+            {
+                Console.WriteLine("Error: Unable to write the endpoint file to disk.");
+                Console.WriteLine("This command requires write permissions to the folder specified with the -w parameter.");
+                return;
+            }
 
             if (string.IsNullOrWhiteSpace(options.Token))
             {
                 options.Token = Guid.NewGuid().ToString();
             }
 
-            updateResourceFileWithToken(fileName, options.Token);
+            try
+            {
+                updateResourceFileWithToken(fileName, options.Token);
+            }
+            catch(UnauthorizedAccessException)
+            {
+                Console.WriteLine("Error: Unable to update endpoint file with security token.");
+                Console.WriteLine("This command requires write permissions to the folder specified with the -w parameter.");
+                return;
+            }
 
             Console.WriteLine($"Deploying {file} to {options.Website}");
             Console.WriteLine($"Security token is: {options.Token}");

--- a/SearchIndexBuilder.App/Processors/Remove/RemoveProcessor.cs
+++ b/SearchIndexBuilder.App/Processors/Remove/RemoveProcessor.cs
@@ -23,7 +23,16 @@ namespace SearchIndexBuilder.App.Processors.Remove
 
             if (File.Exists(fileName))
             {
-                File.Delete(fileName);
+                try
+                {
+                    File.Delete(fileName);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Console.WriteLine("Error: Unable to remove the endpoint file from disk.");
+                    Console.WriteLine("This command requires delete permissions in the folder specified with the -w parameter.");
+                    return;
+                }
                 Console.WriteLine($"Endpoint removed from {options.Website}");
             }
             else


### PR DESCRIPTION
As per bug #1 the tool now catches `UnauthorizedAccessException` thrown by attempts to write (create and updated with security token) or delete the endpoint file. Previous stack trace now replaced with some sensible text noting the need for permissions in the target location.