### PR TITLE
Assorted updates for V1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ This tool tries to help with that by managing the indexing operation from outsid
 something causes the web app to recycle, this tool will detect the error and back off before retrying and continuing
 the process. You can also stop the process and restart it later if necessary.
 
+It will also try to manage errors raised by the Sitecore indexing process - but this behaviour is somewhat limited
+by the data returned from an indexing job by Sitecore. As far as I can tell, most internal failures return a message
+that still looks like success - even if, say, a computed field threw an exception. So you will need to check
+your crawler log to investigate whether any errors which were unreported by Sitecore occurred.
+
 This hasn't been exhaustively tested, as it was something I hacked together to help with a work problem. But it's been
 tried against both Solr and Lucene indexes, with Sitecore v7.1, v7.2 & v9.0 - but in theory it should work with V7.0 and up.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To start the process of re-indexing, you use the `Index` verb. This will take a 
 items it specifies. Using the endpoint you've deployed, the tool will ask Sitecore to reindex each of the items, using each of the indexes
 you have specified. 
 
-`SearchIndexBuilder.App.exe Index [-c <config file>][-o <output Every X items>] [-r <retries in case of error>] [-p <ms to pause for>]`
+`SearchIndexBuilder.App.exe Index [-c <config file>][-o <output Every X items>] [-r <retries in case of error>] [-p <ms to pause for>] [-t <seconds>]`
 
 The parameters are:
 
@@ -134,4 +134,4 @@ The system also supports some global parameters, which will affect all of the ve
 * `-a` / `-attach` (Optional) : Causes the processing to pause between parsing the command line options and starting any processing.
   This allows you to attach a debugger if you need to.
 * `-f` / `-fake` (Optional) : Makes the code use a "fake" object as the endpoint proxy class - allowing it to process some data without a
-  connection to Sitecore being possible.
+  connection to Sitecore being possible. It generates random results for whatever data is being processed.

--- a/SearchIndexBuilder.App/Endpoint/SearchIndexBuilder.EndPoint.aspx
+++ b/SearchIndexBuilder.App/Endpoint/SearchIndexBuilder.EndPoint.aspx
@@ -150,6 +150,7 @@
         public string Index { get; internal set; }
         public string[] Messages { get; internal set; }
         public string Error { get; internal set; }
+        public long Total { get; internal set; }
 
         public void Clear()
         {
@@ -157,6 +158,7 @@
             Index = string.Empty;
             Messages = null;
             Error = null;
+            Total = 0;
         }
     }
 
@@ -166,7 +168,7 @@
 
         public void FlushActivity(Activity a)
         {
-            _items.Add(new { uri = a.Uri, idx = a.Index, msg = a.Messages, err = a.Error });
+            _items.Add(new { uri = a.Uri, idx = a.Index, msg = a.Messages, err = a.Error, total = a.Total });
         }
 
         public string Flush()
@@ -239,6 +241,7 @@
                             string[] strArray = new string[job.Status.Messages.Count];
                             job.Status.Messages.CopyTo(strArray, 0);
                             activity.Messages = strArray;
+                            activity.Total = job.Status.Total;
 
                             log.FlushActivity(activity);
 

--- a/SearchIndexBuilder.App/Endpoint/SearchIndexBuilder.EndPoint.aspx
+++ b/SearchIndexBuilder.App/Endpoint/SearchIndexBuilder.EndPoint.aspx
@@ -96,7 +96,7 @@
         var items = db.SelectItems(query);
 
         var data = items
-            .Select(i => new { Name = i.Name, Id = i.ID.ToString() });
+            .Select(i => new { n = i.Name, i = i.ID.ToString() });
 
         var response = Newtonsoft.Json.JsonConvert.SerializeObject(data);
 
@@ -135,7 +135,7 @@
         }
 
         var data = items
-            .Select(k => new { Name = k.Value, Id = k.Key });
+            .Select(k => new { n = k.Value, i = k.Key });
 
         var response = Newtonsoft.Json.JsonConvert.SerializeObject(data);
 

--- a/SearchIndexBuilder.App/EndpointProxies/Activity.cs
+++ b/SearchIndexBuilder.App/EndpointProxies/Activity.cs
@@ -10,6 +10,7 @@
         public string Index { get; set; }
         public string[] Messages { get; set; }
         public string Error { get; set; }
+        public long Total { get; set; }
     }
 
 }

--- a/SearchIndexBuilder.App/EndpointProxies/ItemEntry.cs
+++ b/SearchIndexBuilder.App/EndpointProxies/ItemEntry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 
 namespace SearchIndexBuilder.App.EndpointProxies
 {
@@ -8,7 +9,9 @@ namespace SearchIndexBuilder.App.EndpointProxies
     /// </summary>
     public class ItemEntry
     {
+        [JsonProperty(PropertyName = "n")]
         public string Name { get; set; }
+        [JsonProperty(PropertyName = "i")]
         public Guid Id { get; set; }
     }
 

--- a/SearchIndexBuilder.App/EndpointProxies/SitecoreWebEndpoint.cs
+++ b/SearchIndexBuilder.App/EndpointProxies/SitecoreWebEndpoint.cs
@@ -56,11 +56,12 @@ namespace SearchIndexBuilder.App.EndpointProxies
 
         public IndexResult IndexItem(string token, ItemEntry itm, string databaseName, IEnumerable<string> indexes, int timeout)
         {
-            WebClient wc = new ExtendedTimeoutWebClient(timeout);
+            var timeoutInMS = timeout * 1000;
+            WebClient wc = new ExtendedTimeoutWebClient(timeoutInMS);
 
             var idx = string.Join(",", indexes);
 
-            var data = wc.DownloadString($"{_url}?cmd=process&db={databaseName}&idx={idx}&id={itm.Id}&t={token}&to={timeout}");
+            var data = wc.DownloadString($"{_url}?cmd=process&db={databaseName}&idx={idx}&id={itm.Id}&t={token}&to={timeoutInMS}");
 
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<Activity[]>(data);
 

--- a/SearchIndexBuilder.App/Processors/ConfigFileManager.cs
+++ b/SearchIndexBuilder.App/Processors/ConfigFileManager.cs
@@ -35,7 +35,7 @@ namespace SearchIndexBuilder.App.Processors
             if (File.Exists(filename))
             {
                 var now = DateTime.Now;
-                var newFile = $"backup-{now.ToString("yyyyMMdd-hhmm")}-{filename}";
+                var newFile = $"backup-{now.ToString("yyyyMMdd-hhmmss")}-{filename}";
 
                 File.Move(filename, newFile);
 

--- a/SearchIndexBuilder.App/Processors/Indexing/IndexingOptions.cs
+++ b/SearchIndexBuilder.App/Processors/Indexing/IndexingOptions.cs
@@ -18,7 +18,7 @@ namespace SearchIndexBuilder.App.Processors.Indexing
         [Option('p', "pause", Required = false, HelpText = "To throttle the effect of the index build on your server, pause for this number of ms between operations.")]
         public int Pause { get; set; } = 0;
 
-        [Option('t', "timeout", Required = false, HelpText = "Allows you to specify a longer timeout for indexing operations. Up to int.MaxValue seconds.")]
+        [Option('t', "timeout", Required = false, HelpText = "Allows you to specify a longer timeout for indexing operations. Expressed in seconds.")]
         public int Timeout { get; set; } = 60;
     }
 

--- a/SearchIndexBuilder.App/Processors/Indexing/IndexingProcessor.cs
+++ b/SearchIndexBuilder.App/Processors/Indexing/IndexingProcessor.cs
@@ -8,18 +8,18 @@ using System.Threading.Tasks;
 namespace SearchIndexBuilder.App.Processors.Indexing
 {
 
-    public class ImprovedIndexingProcessor : BaseProcessor<IndexingOptions>
+    public class IndexingProcessor : BaseProcessor<IndexingOptions>
     {
         public static void RunProcess(IndexingOptions options)
         {
-            var ip = new ImprovedIndexingProcessor(options);
+            var ip = new IndexingProcessor(options);
             ip.Run();
         }
 
         private ConfigFileManager _configFileManager;
         private bool _cancelTriggered = false;
 
-        public ImprovedIndexingProcessor(IndexingOptions options) : base(options)
+        public IndexingProcessor(IndexingOptions options) : base(options)
         {
             _configFileManager = new ConfigFileManager();
             _options = options;

--- a/SearchIndexBuilder.App/Processors/ItemFailure.cs
+++ b/SearchIndexBuilder.App/Processors/ItemFailure.cs
@@ -1,4 +1,5 @@
-﻿using SearchIndexBuilder.App.EndpointProxies;
+﻿using Newtonsoft.Json;
+using SearchIndexBuilder.App.EndpointProxies;
 using System;
 
 namespace SearchIndexBuilder.App.Processors
@@ -6,9 +7,13 @@ namespace SearchIndexBuilder.App.Processors
 
     public class ItemFailure
     {
+        [JsonProperty(PropertyName = "t")]
         public DateTime At { get; set; }
+        [JsonProperty(PropertyName = "i")]
         public ItemEntry Item { get; set; }
+        [JsonProperty(PropertyName = "e")]
         public string[] Errors { get; set; }
+        [JsonProperty(PropertyName = "f")]
         public FailureType FailureType { get; set; }
     }
 

--- a/SearchIndexBuilder.App/Program.cs
+++ b/SearchIndexBuilder.App/Program.cs
@@ -30,7 +30,7 @@ namespace SearchIndexBuilder.App
             parser
                 .ParseArguments<SetupOptions, IndexingOptions, DeployOptions, RemoveOptions, RetryOptions>(args)
                 .WithParsed<SetupOptions>(o => SetupProcessor.RunProcess(o))
-                .WithParsed<IndexingOptions>(o => ImprovedIndexingProcessor.RunProcess(o))
+                .WithParsed<IndexingOptions>(o => IndexingProcessor.RunProcess(o))
                 .WithParsed<DeployOptions>(o => DeployProcessor.RunProcess(o))
                 .WithParsed<RemoveOptions>(o => RemoveProcessor.RunProcess(o))
                 .WithParsed<RetryOptions>(o => RetryProcessor.RunProcess(o));

--- a/SearchIndexBuilder.App/Properties/AssemblyInfo.cs
+++ b/SearchIndexBuilder.App/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/SearchIndexBuilder.App/SearchIndexBuilder.App.csproj
+++ b/SearchIndexBuilder.App/SearchIndexBuilder.App.csproj
@@ -61,7 +61,7 @@
     <Compile Include="Processors\FailureType.cs" />
     <Compile Include="Processors\ConfigFileManager.cs" />
     <Compile Include="Processors\CoreOptions.cs" />
-    <Compile Include="Processors\Indexing\ImprovedIndexingProcessor.cs" />
+    <Compile Include="Processors\Indexing\IndexingProcessor.cs" />
     <Compile Include="Processors\IVerbProcessor.cs" />
     <Compile Include="Processors\ItemFailure.cs" />
     <Compile Include="Processors\Remove\RemoveOptions.cs" />


### PR DESCRIPTION
Optimising the size of the json files a bit by shortening element names, adjusting backup file naming to prevent clashes if it's run twice in a second. Fixing a bug in timeout length calculation due to a units mismatch. And trying to improve error handling from Sitecore - without much success.